### PR TITLE
Module name fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "sergiodxa/use-safe-callback"
   },
   "main": "dist/index.js",
-  "module": "dist/use-mounted-callback.esm.js",
+  "module": "dist/use-safe-callback.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This fixes an issue where some bundlers (Vite in my case) weren't able to find ESM bundle of this package due to the wrong module name in package.json.